### PR TITLE
Jekyll doesn't register the plugin

### DIFF
--- a/_plugins/jekyll-drawio.rb
+++ b/_plugins/jekyll-drawio.rb
@@ -1,0 +1,1 @@
+require_relative "../lib/jekyll-drawio"


### PR DESCRIPTION
```
Liquid Exception: Liquid syntax error (line 16): Unknown tag 'drawio' in <filename>
jekyll 3.9.0 | Error:  Liquid syntax error (line 16): Unknown tag 'drawio'
```